### PR TITLE
Kk cart resource has duplicate line items

### DIFF
--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -50,21 +50,21 @@ class Product(SafeDeleteModel):
     def can_be_rated(self, value):
         self.__can_be_rated = value
 
-    @property
-    def average_rating(self):
-        """Average rating calculated attribute for each product
+    # @property
+    # def average_rating(self):
+    #     """Average rating calculated attribute for each product
 
-        Returns:
-            number -- The average rating for the product
-        """
-        ratings = ProductRating.objects.filter(product=self)
-        total_rating = 0
-        for rating in ratings:
-            total_rating += rating.rating
+    #     Returns:
+    #         number -- The average rating for the product
+    #     """
+    #     ratings = ProductRating.objects.filter(product=self)
+    #     total_rating = 0
+    #     for rating in ratings:
+    #         total_rating += rating.rating
 
-        avg = total_rating / len(ratings)
-        return avg
+    #     avg = total_rating / len(ratings)
+    #     return avg
 
-    class Meta:
-        verbose_name = ("product")
-        verbose_name_plural = ("products")
+    # class Meta:
+    #     verbose_name = ("product")
+    #     verbose_name_plural = ("products")

--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -50,21 +50,24 @@ class Product(SafeDeleteModel):
     def can_be_rated(self, value):
         self.__can_be_rated = value
 
-    # @property
-    # def average_rating(self):
-    #     """Average rating calculated attribute for each product
+    @property
+    def average_rating(self):
+        """Average rating calculated attribute for each product
 
-    #     Returns:
-    #         number -- The average rating for the product
-    #     """
-    #     ratings = ProductRating.objects.filter(product=self)
-    #     total_rating = 0
-    #     for rating in ratings:
-    #         total_rating += rating.rating
+        Returns:
+            number -- The average rating for the product
+        """
+        ratings = ProductRating.objects.filter(product=self)
+        total_rating = 0
+        if total_rating != 0:
+            for rating in ratings:
+                total_rating += rating.rating
 
-    #     avg = total_rating / len(ratings)
-    #     return avg
+            avg = total_rating / len(ratings)
+            return avg
+        else:
+            return 0
 
-    # class Meta:
-    #     verbose_name = ("product")
-    #     verbose_name_plural = ("products")
+    class Meta:
+        verbose_name = ("product")
+        verbose_name_plural = ("products")

--- a/bangazonapi/views/order.py
+++ b/bangazonapi/views/order.py
@@ -26,6 +26,7 @@ class OrderLineItemSerializer(serializers.HyperlinkedModelSerializer):
 
 class OrderSerializer(serializers.HyperlinkedModelSerializer):
     """JSON serializer for customer orders"""
+    lineitems = OrderLineItemSerializer(many=True)
 
     class Meta:
         model = Order
@@ -33,7 +34,7 @@ class OrderSerializer(serializers.HyperlinkedModelSerializer):
             view_name='order',
             lookup_field='id'
         )
-        fields = ('id', 'url', 'created_date', 'payment_type', 'customer')
+        fields = ('id', 'url', 'created_date', 'payment_type', 'customer', "lineitems")
 
 class Orders(ViewSet):
     """View for interacting with customer orders"""

--- a/bangazonapi/views/order.py
+++ b/bangazonapi/views/order.py
@@ -27,16 +27,13 @@ class OrderLineItemSerializer(serializers.HyperlinkedModelSerializer):
 class OrderSerializer(serializers.HyperlinkedModelSerializer):
     """JSON serializer for customer orders"""
 
-    lineitems = OrderLineItemSerializer(many=True)
-
     class Meta:
         model = Order
         url = serializers.HyperlinkedIdentityField(
             view_name='order',
             lookup_field='id'
         )
-        fields = ('id', 'url', 'created_date', 'payment_type', 'customer', 'lineitems')
-
+        fields = ('id', 'url', 'created_date', 'payment_type', 'customer')
 
 class Orders(ViewSet):
     """View for interacting with customer orders"""

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -18,7 +18,7 @@ class ProductSerializer(serializers.ModelSerializer):
     class Meta:
         model = Product
         fields = ('id', 'name', 'price', 'number_sold', 'description',
-                  'quantity', 'created_date', 'location', 'image_path', 'can_be_rated', )
+                  'quantity', 'created_date', 'location', 'image_path', 'can_be_rated', "average_rating")
         depth = 1
 
 

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -18,8 +18,7 @@ class ProductSerializer(serializers.ModelSerializer):
     class Meta:
         model = Product
         fields = ('id', 'name', 'price', 'number_sold', 'description',
-                  'quantity', 'created_date', 'location', 'image_path',
-                  'average_rating', 'can_be_rated', )
+                  'quantity', 'created_date', 'location', 'image_path', 'can_be_rated', )
         depth = 1
 
 

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -178,8 +178,7 @@ class Profile(ViewSet):
                 open_order = Order.objects.get(
                     customer=current_user, payment_type=None)
                 line_items = OrderProduct.objects.filter(order=open_order)
-                line_items = LineItemSerializer(
-                    line_items, many=True, context={'request': request})
+                line_items = LineItemSerializer(line_items, many=True, context={'request': request})
 
                 cart = {}
                 cart["order"] = OrderSerializer(open_order, many=False, context={

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -177,14 +177,11 @@ class Profile(ViewSet):
             try:
                 open_order = Order.objects.get(
                     customer=current_user, payment_type=None)
-                line_items = OrderProduct.objects.filter(order=open_order)
-                line_items = LineItemSerializer(line_items, many=True, context={'request': request})
 
                 cart = {}
                 cart["order"] = OrderSerializer(open_order, many=False, context={
                                                 'request': request}).data
-                cart["order"]["line_items"] = line_items.data
-                cart["order"]["size"] = len(line_items.data)
+                cart["order"]["size"] = len(cart["order"]["lineitems"])
 
             except Order.DoesNotExist as ex:
                 return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
Refactored to remove divided by zero error and to prevent duplicate line items on orders

## Changes

- Removed LintItemSerializer from OrderSerializer, because line item is serialized within cart action in Profile ViewSet
- Added conditional to return 0 if there are no ratings

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

GET `http://localhost:8000/profile/cart` Lists orders in cart

**Response**

HTTP/1.1 200 OK

```json
{
    "id": 8,
    "url": "http://localhost:8000/orders/8",
    "created_date": "2019-03-14",
    "payment_type": null,
    "customer": "http://localhost:8000/customers/5",
    "line_items": [
        {
            "id": 3,
            "product": {
                "id": 21,
                "name": "Rio",
                "price": 1240.2,
                "number_sold": 0,
                "description": "2013 Kia",
                "quantity": 1,
                "created_date": "2019-07-30",
                "location": "Presnenskiy",
                "image_path": null,
                "average_rating": 0
            }
        }
    ],
    "size": 1
}
```

## Testing

Description of how to test code...

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database


## Related Issues

- Fixes #15
- Fixes #24 