### PR TITLE
kk-incorrect-result-for-minimum-products

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -267,7 +267,7 @@ class Products(ViewSet):
 
         if number_sold is not None:
             def sold_filter(product):
-                if product.number_sold <= int(number_sold):
+                if product.number_sold >= int(number_sold):
                     return True
                 return False
 


### PR DESCRIPTION
returns any product sold at least x number of times

Description of PR that completes issue here...

## Changes

- Changed less than symbol to greater than in number_sold filter in Product ViewSet

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

POST `http://localhost:8000/products?number_sold=1` Returns all products that have been sold at least once

**Response**

HTTP/1.1 200 OK

```json
[
    {
        "id": 45,
        "name": "Corvette",
        "price": 795.8,
        "number_sold": 1,
        "description": "1987 Chevrolet",
        "quantity": 2,
        "created_date": "2019-10-07",
        "location": "Ueno",
        "image_path": null,
        "average_rating": 0
    },
    {
        "id": 50,
        "name": "Escalade EXT",
        "price": 926.92,
        "number_sold": 2,
        "description": "2008 Cadillac",
        "quantity": 2,
        "created_date": "2019-02-01",
        "location": "Lokavec",
        "image_path": null,
        "average_rating": 0
    }
]
```

## Testing

Description of how to test code...

Send Postman request with 'number_sold={different numbers}'

## Related Issues

- Fixes #21 