### PR TITLE
Kk get products over specified price

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -249,6 +249,7 @@ class Products(ViewSet):
         order = self.request.query_params.get('order_by', None)
         direction = self.request.query_params.get('direction', None)
         number_sold = self.request.query_params.get('number_sold', None)
+        min_price = self.request.query_params.get('price', None)
 
         if order is not None:
             order_filter = order
@@ -272,6 +273,8 @@ class Products(ViewSet):
                 return False
 
             products = filter(sold_filter, products)
+        if min_price is not None:
+            products = products.filter(price__gte=min_price)
 
         serializer = ProductSerializer(
             products, many=True, context={'request': request})

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -249,7 +249,7 @@ class Products(ViewSet):
         order = self.request.query_params.get('order_by', None)
         direction = self.request.query_params.get('direction', None)
         number_sold = self.request.query_params.get('number_sold', None)
-        min_price = self.request.query_params.get('price', None)
+        min_price = self.request.query_params.get('min_price', None)
 
         if order is not None:
             order_filter = order


### PR DESCRIPTION
Returns any product that is equal to or greater than the min_price query param string

## Changes

- Added variable min_price to capture query string param or None
- Added conditional that filters products by min_price when min_price is not None

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

GET `/products?min_price=300` Returns products where price is greater than the specified number

**Response**

HTTP/1.1 200 OK

```json
[
    {
        "id": 1,
        "name": "Optima",
        "price": 1655.15,
        "number_sold": 0,
        "description": "2008 Kia",
        "quantity": 3,
        "created_date": "2019-05-21",
        "location": "Onguday",
        "image_path": null,
        "average_rating": 0
    },
    {
        "id": 2,
        "name": "Golf",
        "price": 653.59,
        "number_sold": 0,
        "description": "1994 Volkswagen",
        "quantity": 4,
        "created_date": "2019-07-10",
        "location": "Zhongshan",
        "image_path": null,
        "average_rating": 0
    }
]
```

## Testing

Description of how to test code...

- [ ] Send Postman request with a few different numbers to make sure filter is working


## Related Issues

- Fixes #17 